### PR TITLE
update Factorio to the latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM ubuntu:latest
 MAINTAINER Hugh Cannon <hugh@hughcannon.com>
 
 RUN apt-get update &&\
-  apt-get install -y curl && \
+  apt-get install -y curl xz-utils && \
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /factorio
-RUN curl -L -k https://www.factorio.com/get-download/0.13.20/headless/linux64 | tar --strip-components=1 -xzf -
+RUN curl -L -k https://www.factorio.com/get-download/0.15.37/headless/linux64 | tar --strip-components=1 -xJf -
 
 VOLUME ["/factorio/saves"]
 VOLUME ["/factorio/mods"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update &&\
   apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /factorio
-RUN curl -L -k https://www.factorio.com/get-download/0.15.37/headless/linux64 | tar --strip-components=1 -xJf -
+RUN curl -L -k https://www.factorio.com/get-download/latest/headless/linux64 | tar --strip-components=1 -xJf -
 
 VOLUME ["/factorio/saves"]
 VOLUME ["/factorio/mods"]


### PR DESCRIPTION
I've updated the Factorio version to 0.15.37. It uses a tar.xz archive now, so I've added xz-utils and changed the tar flag from `z` to `J`